### PR TITLE
implemented optional MessageFormatter callback

### DIFF
--- a/lib/logstash-amqp.js
+++ b/lib/logstash-amqp.js
@@ -51,6 +51,7 @@ function LogstashStream(options) {
   this.sslCert           = options.sslCert     || '';
   this.sslCA             = options.sslCA       || '';
   this.sslRejectUnauthorized = options.sslRejectUnauthorized || true;
+  this.messageFormatter  = options.messageFormatter;
   
   this.exchange = (typeof options.exchange == 'object') ? options.exchange : { name: options.exchange };
 
@@ -139,6 +140,10 @@ LogstashStream.prototype.write = function logstashWrite(entry) {
     msg['type'] = this.type;
   }
 
+  if (this.messageFormatter) {
+      msg = this.messageFormatter(msg);
+  }
+  
   delete rec.time;
   delete rec.msg;
   delete rec.v;


### PR DESCRIPTION
its handy for harmonizing with other loggers (e.g. log levels are 100-600 instead of 10-60, level is always the number, the name is stored in another field and so on...

usage is as follows:

``` js
        var stream = amqp.createStream({
            //...
            messageFormatter : (message) => {
                //do something with message

                return message;
            }
        });
```
